### PR TITLE
Features/aos 1697 delete app env

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -12,7 +12,20 @@ var deleteCmdForce bool
 var deleteCmd = &cobra.Command{
 	Use:   "delete vault <vaultname> | secret <vaultname> <secretname> | app <appname> | env <envname> | deployment <envname> <appname> | file <filename>",
 	Short: "Delete a resource",
-	Long:  `Delete a resource from the repository.`,
+	Long: `Delete a resource from the repository.
+Deleting a vault will delete all secrets.
+
+Deleting an app will delete the app from all environments it is deployed to.  If this leaves any environment emtpy, the command will also delete the about.json file in the env folder.
+Deleting an environment will delete all the applications in the given env.  If any application is not deployed in another env, the root app.json file is deleted as well.
+Deleting a deployment will delete a specific app from a specific environment.  If the app does not exist in another environment, the root app.json file is deleted as well.  If no other apps are deployed in the given environment, the about.json file are deleted as well
+
+Deleting a specific file will only remove the given filename.  None of the chekcs for related files as done with the delete app, delete env or delete deployment will we executed.
+
+The delete file, vault or secret commands will not ask for any confirmation, but the delete app, env and deployment will ask for confirmation for every file deleted.  It is possible to skip a single delete by pressing N,
+or to cancel all deletions by pressing C.
+
+Specifying the force flag will suppress the confirmation prompts, and delete all matching files.
+`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		var deletecmdObject deletecmd.DeletecmdClass

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -8,14 +8,15 @@ import (
 	"os"
 )
 
+var deleteCmdForce bool
 var deleteCmd = &cobra.Command{
-	Use:   "delete vault <vaultname> | secret <vaultname> <secretname> | app <appname> | env <envname> | deployment <appname> <envname>",
+	Use:   "delete vault <vaultname> | secret <vaultname> <secretname> | app <appname> | env <envname> | deployment <envname> <appname> | file <filename>",
 	Short: "Delete a resource",
 	Long:  `Delete a resource from the repository.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		var deletecmdObject deletecmd.DeletecmdClass
-		output, err := deletecmdObject.DeleteObject(args, &persistentOptions)
+		output, err := deletecmdObject.DeleteObject(args, deleteCmdForce, &persistentOptions)
 		if err != nil {
 			l := log.New(os.Stderr, "", 0)
 			l.Println(err.Error())
@@ -30,4 +31,5 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(deleteCmd)
+	deleteCmd.Flags().BoolVarP(&deleteCmdForce, "force", "f", false, "ignore nonexistent files and arguments, never prompt")
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -9,7 +9,7 @@ import (
 )
 
 var deleteCmd = &cobra.Command{
-	Use:   "delete vault <vaultname> | secret <vaultname> <secretname>",
+	Use:   "delete vault <vaultname> | secret <vaultname> <secretname> | app <appname> | env <envname> | deployment <appname> <envname>",
 	Short: "Delete a resource",
 	Long:  `Delete a resource from the repository.`,
 

--- a/pkg/executil/executil.go
+++ b/pkg/executil/executil.go
@@ -1,11 +1,14 @@
 package executil
 
 import (
+	"bufio"
 	"errors"
+	"fmt"
 	"github.com/skatteetaten/aoc/pkg/fileutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 const commandNotFound = "Command not found"
@@ -45,4 +48,22 @@ func RunInteractively(commandString string, foldername string, args ...string) (
 		return err
 	}
 	return nil
+}
+
+// Prompt for Yes, No or Cancel
+func PromptYNC(promptString string) (retval string, err error) {
+	var validResponse bool = false
+	reader := bufio.NewReader(os.Stdin)
+	for !validResponse {
+		fmt.Print(promptString + " (Yes/No/Cancel): ")
+		result, err := reader.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		if strings.ContainsAny("YyNnCcYesNoCancel", result) {
+			return strings.ToUpper(string(result[0])), nil
+		}
+
+	}
+	return
 }


### PR DESCRIPTION
Delete files, deployments, envs and apps from the AuroraConfig.  Related files (/about.json in empty folders and root app.json without any deployments) are deleted as well.